### PR TITLE
Added the `noInlineSxPropRule` and fixed existing `sx` references #5

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ import pluginNext from '@next/eslint-plugin-next';
 import globals from 'globals';
 import enforceStyledPrefixRule from './eslintRules/enforceStyledPrefixRule.js';
 import enforceStyledCallbackRule from './eslintRules/enforceStyledCallbackRule.js';
+import noInlineSxPropRule from './eslintRules/noInlineSxPropRule.js';
 
 export default [
   {
@@ -60,6 +61,7 @@ export default [
         rules: {
           'enforce-styled-prefix': enforceStyledPrefixRule,
           'enforce-styled-callback': enforceStyledCallbackRule,
+          'no-inline-sx-prop': noInlineSxPropRule,
         },
       },
     },
@@ -87,6 +89,7 @@ export default [
 
       'custom/enforce-styled-prefix': 'error',
       'custom/enforce-styled-callback': 'error',
+      'custom/no-inline-sx-prop': 'error',
     },
   },
 ];

--- a/eslintRules/noInlineSxPropRule.js
+++ b/eslintRules/noInlineSxPropRule.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Disallow inline usage of the sx prop.
+ * Prefer styled components, or if necessary, reference a declared style object.
+ */
+
+const noInlineSxPropRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow inline usage of the sx prop in JSX',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noInlineSx: 'Inline sx prop is not allowed. Prefer styled components or reference a declared style object.',
+    },
+  },
+
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        // We only care about attributes named "sx"
+        if (node.name.name !== 'sx') {
+          return;
+        }
+
+        // If the attribute value is something like sx="string", or there's no value, just ignore.
+        if (!node.value || node.value.type !== 'JSXExpressionContainer') {
+          return;
+        }
+
+        // Now we have sx={<some expression>}. We want to disallow inline object/array.
+        const expression = node.value.expression;
+        if (expression.type === 'ObjectExpression' || expression.type === 'ArrayExpression') {
+          // This means sx={{ ... }} or sx={[ ... ]} – report an error
+          context.report({
+            node,
+            messageId: 'noInlineSx',
+          });
+        }
+      },
+    };
+  },
+};
+
+export default noInlineSxPropRule;

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { createContext, useContext, ReactNode } from 'react';
 import { SnackbarProvider, useSnackbar, VariantType } from 'notistack';
-import { IconButton } from '@mui/material';
+import { IconButton, styled } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 
 export type SetAlert = (message: string, variant: VariantType) => void;
@@ -41,9 +41,9 @@ const AlertContextProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       variant,
 
       action: (key) => (
-        <IconButton size="small" onClick={() => closeSnackbar(key)} sx={{ color: 'inherit' }}>
+        <StyledIconButton size="small" onClick={() => closeSnackbar(key)}>
           <CloseIcon fontSize="small" />
-        </IconButton>
+        </StyledIconButton>
       ),
     });
   };
@@ -61,3 +61,7 @@ export const useAlert = (): AlertContextType => {
   }
   return context;
 };
+
+const StyledIconButton = styled(IconButton)(() => ({
+  color: 'inherit',
+}));

--- a/src/components/HorizontalLinearStepper.tsx
+++ b/src/components/HorizontalLinearStepper.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { styled } from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Step from '@mui/material/Step';
@@ -60,17 +61,9 @@ export default function HorizontalLinearStepper({
   }, [setActiveStep]);
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        flexDirection: 'column',
-        maxWidth: 1200,
-      }}
-    >
-      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-        <Stepper activeStep={activeStep} sx={{ width: stepperWidth }}>
+    <StyledContainer>
+      <StyledStepperContainer>
+        <StyledStepper activeStep={activeStep} stepperWidth={stepperWidth}>
           {stepNames.map((label) => {
             const stepProps: { completed?: boolean } = {};
             const labelProps: {
@@ -82,25 +75,25 @@ export default function HorizontalLinearStepper({
               </Step>
             );
           })}
-        </Stepper>
-      </Box>
+        </StyledStepper>
+      </StyledStepperContainer>
 
       {activeStep === stepNames.length ? (
         <Fragment>
-          <Typography sx={{ mt: 2, mb: 1 }}>All steps completed - you&apos;re finished</Typography>
-          <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
-            <Box sx={{ flex: '1 1 auto' }} />
+          <StyledStepsCompleted>All steps completed - you&apos;re finished</StyledStepsCompleted>
+          <StyledResetContainer>
+            <StyledSpacer />
             <Button onClick={handleReset}>Reset</Button>
-          </Box>
+          </StyledResetContainer>
         </Fragment>
       ) : (
         <Fragment>
           {stepContent}
-          <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
-            <Button color="inherit" disabled={activeStep === 0} onClick={handleBack} sx={{ mr: 1 }}>
+          <StyledFooterContainer>
+            <StyledBackButton color="inherit" disabled={activeStep === 0} onClick={handleBack}>
               Back
-            </Button>
-            <Box sx={{ flex: '1 1 auto' }} />
+            </StyledBackButton>
+            <StyledSpacer />
             {activeStep !== stepNames.length - 1 ? (
               <Button onClick={handleNext} disabled={nextDisabled || loading}>
                 Next
@@ -117,9 +110,53 @@ export default function HorizontalLinearStepper({
                 </Button>
               </>
             )}
-          </Box>
+          </StyledFooterContainer>
         </Fragment>
       )}
-    </Box>
+    </StyledContainer>
   );
 }
+
+const StyledContainer = styled(Box)(() => ({
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  maxWidth: 1200,
+}));
+
+const StyledStepper = styled(Stepper, {
+  shouldForwardProp: (prop) => prop !== 'stepperWidth',
+})<{ stepperWidth: number }>(({ stepperWidth }) => ({
+  width: stepperWidth,
+}));
+
+const StyledStepperContainer = styled(Box)(() => ({
+  display: 'flex',
+  justifyContent: 'center',
+}));
+
+const StyledStepsCompleted = styled(Typography)(({ theme }) => ({
+  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(1),
+}));
+
+const StyledResetContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  paddingTop: theme.spacing(2),
+}));
+
+const StyledSpacer = styled(Box)(() => ({
+  flex: '1 1 auto',
+}));
+
+const StyledFooterContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  paddingTop: theme.spacing(2),
+}));
+
+const StyledBackButton = styled(Button)(({ theme }) => ({
+  marginRight: theme.spacing(1),
+}));

--- a/src/components/Inputs/FormCheckbox.tsx
+++ b/src/components/Inputs/FormCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControl, FormControlLabel, FormHelperText, Tooltip } from '@mui/material';
+import { Checkbox, FormControl, FormControlLabel, FormHelperText, styled, Tooltip } from '@mui/material';
 import { Controller, useFormContext, FieldValues, Path, ControllerRenderProps } from 'react-hook-form';
 import { get } from 'lodash';
 import { useCallback } from 'react';
@@ -44,7 +44,7 @@ export function FormCheckbox<TFieldValues extends FieldValues>({
   );
 
   return (
-    <FormControl error={Boolean(errorMessage)} sx={{ width: '100%' }}>
+    <StyledFormControl error={Boolean(errorMessage)}>
       <Tooltip title={tooltip || ''} arrow enterDelay={2000} leaveDelay={200} placement="top" enterNextDelay={2000}>
         <>
           <Controller control={control} name={name} render={controllerRenderer} />
@@ -53,6 +53,10 @@ export function FormCheckbox<TFieldValues extends FieldValues>({
           )}
         </>
       </Tooltip>
-    </FormControl>
+    </StyledFormControl>
   );
 }
+
+const StyledFormControl = styled(FormControl)(() => ({
+  width: '100%',
+}));

--- a/src/components/Inputs/FormMultiSelect/FormMultiSelect.tsx
+++ b/src/components/Inputs/FormMultiSelect/FormMultiSelect.tsx
@@ -1,6 +1,6 @@
 import Autocomplete, { AutocompleteRenderInputParams } from '@mui/material/Autocomplete';
 import { Controller, useFormContext, FieldValues, Path, ControllerRenderProps } from 'react-hook-form';
-import { FormControl, TextField, FormHelperText } from '@mui/material';
+import { FormControl, TextField, FormHelperText, styled } from '@mui/material';
 import Tooltip from '@mui/material/Tooltip';
 import { get } from 'lodash';
 import { SyntheticEvent, useCallback } from 'react';
@@ -109,7 +109,7 @@ export function FormMultiSelect<TFieldValues extends FieldValues>({
   );
 
   return (
-    <FormControl sx={{ width: '100%' }} error={Boolean(errorMessage)}>
+    <StyledFormControl error={Boolean(errorMessage)}>
       <Tooltip title={tooltip || ''} arrow enterDelay={2000} leaveDelay={200} placement="top" enterNextDelay={2000}>
         <>
           <Controller control={control} name={name} render={controllerRenderer} />
@@ -118,6 +118,10 @@ export function FormMultiSelect<TFieldValues extends FieldValues>({
           )}
         </>
       </Tooltip>
-    </FormControl>
+    </StyledFormControl>
   );
 }
+
+const StyledFormControl = styled(FormControl)(() => ({
+  width: '100%',
+}));

--- a/src/components/Inputs/FormSelect/FormSelect.tsx
+++ b/src/components/Inputs/FormSelect/FormSelect.tsx
@@ -1,6 +1,6 @@
 import Autocomplete, { AutocompleteRenderInputParams } from '@mui/material/Autocomplete';
 import { Controller, useFormContext, FieldValues, Path, ControllerRenderProps } from 'react-hook-form';
-import { FormControl, TextField, Tooltip, FormHelperText } from '@mui/material';
+import { FormControl, TextField, Tooltip, FormHelperText, styled } from '@mui/material';
 import { get } from 'lodash';
 import { SyntheticEvent, useCallback } from 'react';
 import { Option } from '@Components/Inputs/FormMultiSelect/FormMultiSelect';
@@ -109,7 +109,7 @@ export function FormSelect<TFieldValues extends FieldValues>({
   );
 
   return (
-    <FormControl sx={{ width: '100%' }} error={Boolean(errorMessage)}>
+    <StyledFormControl error={Boolean(errorMessage)}>
       <Tooltip title={tooltip || ''} arrow enterDelay={2000} leaveDelay={200} placement="top" enterNextDelay={2000}>
         <>
           <Controller control={control} name={name} render={controllerRenderer} />
@@ -118,6 +118,10 @@ export function FormSelect<TFieldValues extends FieldValues>({
           )}
         </>
       </Tooltip>
-    </FormControl>
+    </StyledFormControl>
   );
 }
+
+const StyledFormControl = styled(FormControl)(() => ({
+  width: '100%',
+}));

--- a/src/components/forms/FormDialog.tsx
+++ b/src/components/forms/FormDialog.tsx
@@ -8,6 +8,7 @@ import {
   Fade,
   Box,
   DialogContentText,
+  styled,
 } from '@mui/material';
 import { InferType } from 'yup';
 import React, { useCallback } from 'react';
@@ -49,7 +50,7 @@ export const FormDialog = <T extends AnySchema>({
   const formContent = (
     <>
       <Fade in={submitLoading} unmountOnExit>
-        <LinearProgress sx={{ width: '100%' }} color="success" />
+        <StyledLinearProgress color="success" />
       </Fade>
       {title && <DialogTitle>{title}</DialogTitle>}
       <DialogContent>
@@ -86,3 +87,7 @@ export const FormDialog = <T extends AnySchema>({
     </Dialog>
   );
 };
+
+const StyledLinearProgress = styled(LinearProgress)(() => ({
+  width: '100%',
+}));

--- a/src/connected-components/Layout/Header.tsx
+++ b/src/connected-components/Layout/Header.tsx
@@ -1,6 +1,13 @@
 'use client';
+
+import { styled } from '@mui/material';
 import Toolbar from '@mui/material/Toolbar';
 
 export const Header = () => {
-  return <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}></Toolbar>;
+  return <StyledToolbar />;
 };
+
+const StyledToolbar = styled(Toolbar)(() => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+}));


### PR DESCRIPTION
Added the `noInlineSxPropRule` which prevents inline `sx` usage. Devs should prefer styled components type syntax or provide to the sx prop with a declared var.

Resolves #5 