### PR TITLE
Prevent inline style prop

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -43,12 +43,16 @@ export default async function RootLayout({
 
   const messages = await getMessages();
 
+  const bodyStyle = {
+    margin: '0px',
+  };
+
   return (
     <html lang={locale} className={montserrat.className}>
       <AppRouterCacheProvider>
         <ThemeProvider theme={theme}>
           <CssBaseline enableColorScheme />
-          <body style={{ margin: '0px' }} suppressHydrationWarning>
+          <body style={bodyStyle} suppressHydrationWarning>
             <NextIntlClientProvider messages={messages}>
               <ReduxProvider>{children}</ReduxProvider>
             </NextIntlClientProvider>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ import globals from 'globals';
 import enforceStyledPrefixRule from './eslintRules/enforceStyledPrefixRule.js';
 import enforceStyledCallbackRule from './eslintRules/enforceStyledCallbackRule.js';
 import noInlineSxPropRule from './eslintRules/noInlineSxPropRule.js';
+import noInlineStylePropRule from './eslintRules/noInlineStylePropRule.js';
 
 export default [
   {
@@ -62,6 +63,7 @@ export default [
           'enforce-styled-prefix': enforceStyledPrefixRule,
           'enforce-styled-callback': enforceStyledCallbackRule,
           'no-inline-sx-prop': noInlineSxPropRule,
+          'no-inline-style-prop': noInlineStylePropRule,
         },
       },
     },
@@ -90,6 +92,7 @@ export default [
       'custom/enforce-styled-prefix': 'error',
       'custom/enforce-styled-callback': 'error',
       'custom/no-inline-sx-prop': 'error',
+      'custom/no-inline-style-prop': 'error',
     },
   },
 ];

--- a/eslintRules/noInlineStylePropRule.js
+++ b/eslintRules/noInlineStylePropRule.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Disallow inline usage of the style prop.
+ * Prefer using styled components or referencing a declared style object.
+ */
+
+// There's a lot of duplication across these rules. Should consolidate this at some point.
+
+const noInlineStylePropRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow inline usage of the style prop in JSX',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noInlineStyle: 'Inline style prop is not allowed. Prefer styled components or reference a declared style object.',
+    },
+  },
+
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        // 1) Only care about attributes named "style".
+        if (node.name.name !== 'style') {
+          return;
+        }
+
+        // 2) If the attribute is style="string" or no value, skip.
+        if (!node.value || node.value.type !== 'JSXExpressionContainer') {
+          return;
+        }
+
+        // 3) If style is an expression container, check if it's an inline object/array.
+        const expression = node.value.expression;
+
+        // Typically you'd only see object for style,
+        // but let's include array for completeness.
+        if (expression.type === 'ObjectExpression' || expression.type === 'ArrayExpression') {
+          context.report({
+            node,
+            messageId: 'noInlineStyle',
+          });
+        }
+
+        // If it's referencing a variable or function (style={someVar}), that's allowed.
+      },
+    };
+  },
+};
+
+export default noInlineStylePropRule;

--- a/src/components/forms/Form.tsx
+++ b/src/components/forms/Form.tsx
@@ -1,4 +1,5 @@
 // Form.tsx
+import { styled } from '@mui/material';
 import React from 'react';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { AnySchema, InferType } from 'yup';
@@ -20,10 +21,15 @@ export const Form = <T extends AnySchema>({
 }: FormProps<T>) => (
   <FormProvider {...methods}>
     <form onSubmit={methods.handleSubmit(onFormSubmit)}>
-      <fieldset disabled={disabled} style={{ border: 'none', padding: 0 }}>
+      <StyledFieldset disabled={disabled}>
         {renderFormContent?.()}
         {actions}
-      </fieldset>
+      </StyledFieldset>
     </form>
   </FormProvider>
 );
+
+const StyledFieldset = styled('fieldset')(() => ({
+  border: 'none',
+  padding: 0,
+}));


### PR DESCRIPTION
- Added `noInlineStyleProp` eslint rule to disallow inline style prop usage and fixed existing offending code #9

Resolves #9 