### PR TITLE
Improved metadata on blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { client } from '@Root/sanity/lib/client';
 import { SanityDocument } from 'next-sanity';
 import { GET_BLOG_POST_FOR_BLOG_PAGE } from '@Root/sanity/queries/getBlogPostForBlogPage';
 import { BlogPost } from '@Features/BlogPost/BlogPost';
+import { Metadata } from 'next';
 
 export const revalidate = 30;
 
@@ -17,6 +18,55 @@ interface PostPageProps {
 }
 
 type tParams = Promise<{ slug: string }>;
+
+// Generate metadata for the page including Open Graph tags
+export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
+  // Fetch data for this specific post
+  const post = await getSinglePost(params.slug);
+
+  // If post doesn't exist, return minimal metadata
+  if (!post) {
+    return {
+      title: 'Post Not Found',
+      description: 'This blog post could not be found.',
+    };
+  }
+
+  // Extract the hero image URL from the post data
+  const heroImageUrl = post.mainImage?.asset?.url;
+
+  console.log('heroImageUrl', heroImageUrl);
+
+  // Format the absolute URL for the blog post
+  const postUrl = `https://bobbygagnon.com/blog/${params.slug}`;
+
+  return {
+    title: post.title,
+    description: post.excerpt || post.description || "Read more on Bobby Gagnon's blog",
+    openGraph: {
+      title: post.title,
+      description: post.excerpt || post.description || "Read more on Bobby Gagnon's blog",
+      url: postUrl,
+      siteName: 'Bobby Gagnon',
+      images: [
+        {
+          url: heroImageUrl,
+          width: 1200,
+          height: 630,
+          alt: post.title,
+        },
+      ],
+      type: 'article',
+      locale: 'en_US',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt || post.description || "Read more on Bobby Gagnon's blog",
+      images: [heroImageUrl],
+    },
+  };
+}
 
 export default async function PostPage({ params }: PostPageProps) {
   const { slug } = await params;

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -20,9 +20,12 @@ interface PostPageProps {
 type tParams = Promise<{ slug: string }>;
 
 // Generate metadata for the page including Open Graph tags
-export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
+export async function generateMetadata({ params }: PostPageProps): Promise<Metadata> {
+  // Handle the Promise-wrapped params
+  const { slug } = await params;
+
   // Fetch data for this specific post
-  const post = await getSinglePost(params.slug);
+  const post = await getSinglePost(slug);
 
   // If post doesn't exist, return minimal metadata
   if (!post) {
@@ -33,12 +36,10 @@ export async function generateMetadata({ params }: { params: { slug: string } })
   }
 
   // Extract the hero image URL from the post data
-  const heroImageUrl = post.mainImage?.asset?.url;
-
-  console.log('heroImageUrl', heroImageUrl);
+  const heroImageUrl = post.mainImage?.asset?.url || '/public/images/portfolio-preview.png';
 
   // Format the absolute URL for the blog post
-  const postUrl = `https://bobbygagnon.com/blog/${params.slug}`;
+  const postUrl = `https://bobbygagnon.com/blog/${slug}`;
 
   return {
     title: post.title,


### PR DESCRIPTION
This pull request includes changes to the `app/blog/[slug]/page.tsx` file to enhance the metadata generation for blog posts. The key changes involve importing the `Metadata` type from `next` and adding a new function to generate metadata, including Open Graph tags and Twitter card information.

Metadata generation improvements:

* `app/blog/[slug]/page.tsx`: Added import for `Metadata` from `next`. ([app/blog/[slug]/page.tsxR7](diffhunk://#diff-e55d8a1e2ca072b0faa39e40d3ae472b0d6cca164d371ab5e86e8ab7ba85960cR7))
* `app/blog/[slug]/page.tsx`: Added `generateMetadata` function to fetch post data and generate metadata, including Open Graph tags and Twitter card information. ([app/blog/[slug]/page.tsxR22-R70](diffhunk://#diff-e55d8a1e2ca072b0faa39e40d3ae472b0d6cca164d371ab5e86e8ab7ba85960cR22-R70))